### PR TITLE
Fix MCP servers Accept header handling

### DIFF
--- a/mcp/build-mcp/src/index.ts
+++ b/mcp/build-mcp/src/index.ts
@@ -26,8 +26,19 @@ const r = await $`bash -lc ${cmd}`.nothrow(); return { ok: r.exitCode===0, outpu
 
 
 const app = express(); app.use(express.json());
-app.post("/mcp", async (req,res)=>{ const t=new StreamableHTTPServerTransport({enableJsonResponse:true}); res.on("close",()=>t.close()); await server.connect(t); await t.handleRequest(req,res,req.body); });
+
+function ensureAcceptHeader(req: express.Request) {
+  const header = req.headers["accept"];
+  const joined = Array.isArray(header) ? header.join(",") : header ?? "";
+  const parts = joined.split(",").map((p) => p.trim()).filter(Boolean);
+  if (!parts.some((p) => p.includes("application/json"))) parts.push("application/json");
+  if (!parts.some((p) => p.includes("text/event-stream"))) parts.push("text/event-stream");
+  req.headers["accept"] = parts.join(", ");
+}
+
+app.post("/mcp", async (req,res)=>{ ensureAcceptHeader(req); const t=new StreamableHTTPServerTransport({enableJsonResponse:true}); res.on("close",()=>t.close()); await server.connect(t); await t.handleRequest(req,res,req.body); });
 app.post("/", async (req, res) => {
+  ensureAcceptHeader(req);
   const t = new StreamableHTTPServerTransport({ enableJsonResponse: true });
   res.on("close", () => t.close());
   await server.connect(t);

--- a/mcp/pkg-mcp/src/index.ts
+++ b/mcp/pkg-mcp/src/index.ts
@@ -25,10 +25,20 @@ reg("pkg.install",
 );
 
 const app = express(); app.use(express.json());
-app.post("/mcp", async (req,res)=>{ const t=new StreamableHTTPServerTransport({ enableJsonResponse:true });
+
+function ensureAcceptHeader(req: express.Request) {
+  const header = req.headers["accept"];
+  const joined = Array.isArray(header) ? header.join(",") : header ?? "";
+  const parts = joined.split(",").map((p) => p.trim()).filter(Boolean);
+  if (!parts.some((p) => p.includes("application/json"))) parts.push("application/json");
+  if (!parts.some((p) => p.includes("text/event-stream"))) parts.push("text/event-stream");
+  req.headers["accept"] = parts.join(", ");
+}
+
+app.post("/mcp", async (req,res)=>{ ensureAcceptHeader(req); const t=new StreamableHTTPServerTransport({ enableJsonResponse:true });
   res.on("close",()=>t.close()); await server.connect(t); await t.handleRequest(req,res,req.body); });
 // importante: raíz “/”
-app.post("/", async (req,res)=>{ const t=new StreamableHTTPServerTransport({ enableJsonResponse:true });
+app.post("/", async (req,res)=>{ ensureAcceptHeader(req); const t=new StreamableHTTPServerTransport({ enableJsonResponse:true });
   res.on("close",()=>t.close()); await server.connect(t); await t.handleRequest(req,res,req.body); });
 
 app.listen(3004, ()=>console.log("pkg-mcp http://localhost:3004/{mcp|}"));

--- a/mcp/test-mcp/src/index.ts
+++ b/mcp/test-mcp/src/index.ts
@@ -26,8 +26,19 @@ const r = await $`bash -lc ${cmd}`.nothrow(); return { ok: r.exitCode===0, outpu
 
 
 const app = express(); app.use(express.json());
-app.post("/mcp", async (req,res)=>{ const t=new StreamableHTTPServerTransport({enableJsonResponse:true}); res.on("close",()=>t.close()); await server.connect(t); await t.handleRequest(req,res,req.body); });
+
+function ensureAcceptHeader(req: express.Request) {
+  const header = req.headers["accept"];
+  const joined = Array.isArray(header) ? header.join(",") : header ?? "";
+  const parts = joined.split(",").map((p) => p.trim()).filter(Boolean);
+  if (!parts.some((p) => p.includes("application/json"))) parts.push("application/json");
+  if (!parts.some((p) => p.includes("text/event-stream"))) parts.push("text/event-stream");
+  req.headers["accept"] = parts.join(", ");
+}
+
+app.post("/mcp", async (req,res)=>{ ensureAcceptHeader(req); const t=new StreamableHTTPServerTransport({enableJsonResponse:true}); res.on("close",()=>t.close()); await server.connect(t); await t.handleRequest(req,res,req.body); });
 app.post("/", async (req, res) => {
+  ensureAcceptHeader(req);
   const t = new StreamableHTTPServerTransport({ enableJsonResponse: true });
   res.on("close", () => t.close());
   await server.connect(t);


### PR DESCRIPTION
## Summary
- ensure every MCP HTTP endpoint augments missing Accept values so clients that only request JSON still meet the Streamable HTTP contract
- keep existing tool handlers unchanged while avoiding 406 errors during tool discovery

## Testing
- `curl -s -D - -X POST http://localhost:3004/ -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'`


------
https://chatgpt.com/codex/tasks/task_b_68e1c144ff9c8332a4f87059b0756239