### PR TITLE
Support MCP GET handshake endpoints

### DIFF
--- a/mcp/lint-mcp/src/index.ts
+++ b/mcp/lint-mcp/src/index.ts
@@ -23,19 +23,39 @@ reg("lint.back", { lang: z.string().optional() }, "Run backend linter", async ({
 
 const app = express(); app.use(express.json());
 
+function ensureAcceptHeader(req: express.Request, { includeJson = true } = {}) {
+  const header = req.headers["accept"];
+  const joined = Array.isArray(header) ? header.join(",") : header ?? "";
+  const parts = joined.split(",").map((p) => p.trim()).filter(Boolean);
+  if (includeJson && !parts.some((p) => p.includes("application/json"))) parts.push("application/json");
+  if (!parts.some((p) => p.includes("text/event-stream"))) parts.push("text/event-stream");
+  req.headers["accept"] = parts.join(", ");
+}
+
+async function handleMcpRequest(req: express.Request, res: express.Response, body?: unknown) {
+  const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
+  res.on("close", () => transport.close());
+  await server.connect(transport);
+  await transport.handleRequest(req, res, body);
+}
+
 // MCP en /mcp
+app.get("/mcp", async (req, res) => {
+  ensureAcceptHeader(req, { includeJson: false });
+  await handleMcpRequest(req, res);
+});
 app.post("/mcp", async (req, res) => {
-  const t = new StreamableHTTPServerTransport({ enableJsonResponse: true });
-  res.on("close", () => t.close());
-  await server.connect(t);
-  await t.handleRequest(req, res, req.body);
+  ensureAcceptHeader(req);
+  await handleMcpRequest(req, res, req.body);
 });
 // MCP también en la raíz /
+app.get("/", async (req, res) => {
+  ensureAcceptHeader(req, { includeJson: false });
+  await handleMcpRequest(req, res);
+});
 app.post("/", async (req, res) => {
-  const t = new StreamableHTTPServerTransport({ enableJsonResponse: true });
-  res.on("close", () => t.close());
-  await server.connect(t);
-  await t.handleRequest(req, res, req.body);
+  ensureAcceptHeader(req);
+  await handleMcpRequest(req, res, req.body);
 });
 
 app.listen(3003, () => console.log("lint-mcp http://localhost:3003/{mcp|}"));

--- a/mcp/pkg-mcp/src/index.ts
+++ b/mcp/pkg-mcp/src/index.ts
@@ -25,10 +25,27 @@ reg("pkg.install",
 );
 
 const app = express(); app.use(express.json());
-app.post("/mcp", async (req,res)=>{ const t=new StreamableHTTPServerTransport({ enableJsonResponse:true });
-  res.on("close",()=>t.close()); await server.connect(t); await t.handleRequest(req,res,req.body); });
+
+function ensureAcceptHeader(req: express.Request, { includeJson = true } = {}) {
+  const header = req.headers["accept"];
+  const joined = Array.isArray(header) ? header.join(",") : header ?? "";
+  const parts = joined.split(",").map((p) => p.trim()).filter(Boolean);
+  if (includeJson && !parts.some((p) => p.includes("application/json"))) parts.push("application/json");
+  if (!parts.some((p) => p.includes("text/event-stream"))) parts.push("text/event-stream");
+  req.headers["accept"] = parts.join(", ");
+}
+
+async function handleMcpRequest(req: express.Request, res: express.Response, body?: unknown) {
+  const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
+  res.on("close", () => transport.close());
+  await server.connect(transport);
+  await transport.handleRequest(req, res, body);
+}
+
+app.get("/mcp", async (req,res)=>{ ensureAcceptHeader(req, { includeJson: false }); await handleMcpRequest(req,res); });
+app.post("/mcp", async (req,res)=>{ ensureAcceptHeader(req); await handleMcpRequest(req,res,req.body); });
 // importante: raíz “/”
-app.post("/", async (req,res)=>{ const t=new StreamableHTTPServerTransport({ enableJsonResponse:true });
-  res.on("close",()=>t.close()); await server.connect(t); await t.handleRequest(req,res,req.body); });
+app.get("/", async (req,res)=>{ ensureAcceptHeader(req, { includeJson: false }); await handleMcpRequest(req,res); });
+app.post("/", async (req,res)=>{ ensureAcceptHeader(req); await handleMcpRequest(req,res,req.body); });
 
 app.listen(3004, ()=>console.log("pkg-mcp http://localhost:3004/{mcp|}"));

--- a/mcp/repo-mcp/src/index.ts
+++ b/mcp/repo-mcp/src/index.ts
@@ -73,18 +73,38 @@ registerTool(
 const app = express();
 app.use(express.json());
 
-app.post("/mcp", async (req, res) => {
+function ensureAcceptHeader(req: express.Request, { includeJson = true } = {}) {
+  const header = req.headers["accept"];
+  const joined = Array.isArray(header) ? header.join(",") : header ?? "";
+  const parts = joined.split(",").map((p) => p.trim()).filter(Boolean);
+  if (includeJson && !parts.some((p) => p.includes("application/json"))) parts.push("application/json");
+  if (!parts.some((p) => p.includes("text/event-stream"))) parts.push("text/event-stream");
+  req.headers["accept"] = parts.join(", ");
+}
+
+async function handleMcpRequest(req: express.Request, res: express.Response, body?: unknown) {
   const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
   res.on("close", () => transport.close());
   await server.connect(transport);
-  await transport.handleRequest(req, res, req.body);
+  await transport.handleRequest(req, res, body);
+}
+
+app.get("/mcp", async (req, res) => {
+  ensureAcceptHeader(req, { includeJson: false });
+  await handleMcpRequest(req, res);
+});
+app.post("/mcp", async (req, res) => {
+  ensureAcceptHeader(req);
+  await handleMcpRequest(req, res, req.body);
 });
 
+app.get("/", async (req, res) => {
+  ensureAcceptHeader(req, { includeJson: false });
+  await handleMcpRequest(req, res);
+});
 app.post("/", async (req, res) => {
-  const t = new StreamableHTTPServerTransport({ enableJsonResponse: true });
-  res.on("close", () => t.close());
-  await server.connect(t);
-  await t.handleRequest(req, res, req.body);
+  ensureAcceptHeader(req);
+  await handleMcpRequest(req, res, req.body);
 });
 
 app.post("/tool/:name", async (req, res) => {

--- a/mcp/test-mcp/src/index.ts
+++ b/mcp/test-mcp/src/index.ts
@@ -26,12 +26,35 @@ const r = await $`bash -lc ${cmd}`.nothrow(); return { ok: r.exitCode===0, outpu
 
 
 const app = express(); app.use(express.json());
-app.post("/mcp", async (req,res)=>{ const t=new StreamableHTTPServerTransport({enableJsonResponse:true}); res.on("close",()=>t.close()); await server.connect(t); await t.handleRequest(req,res,req.body); });
+
+function ensureAcceptHeader(req: express.Request, { includeJson = true } = {}) {
+  const header = req.headers["accept"];
+  const joined = Array.isArray(header) ? header.join(",") : header ?? "";
+  const parts = joined.split(",").map((p) => p.trim()).filter(Boolean);
+  if (includeJson && !parts.some((p) => p.includes("application/json"))) parts.push("application/json");
+  if (!parts.some((p) => p.includes("text/event-stream"))) parts.push("text/event-stream");
+  req.headers["accept"] = parts.join(", ");
+}
+
+async function handleMcpRequest(req: express.Request, res: express.Response, body?: unknown) {
+  const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
+  res.on("close", () => transport.close());
+  await server.connect(transport);
+  await transport.handleRequest(req, res, body);
+}
+
+app.get("/mcp", async (req, res) => {
+  ensureAcceptHeader(req, { includeJson: false });
+  await handleMcpRequest(req, res);
+});
+app.get("/", async (req, res) => {
+  ensureAcceptHeader(req, { includeJson: false });
+  await handleMcpRequest(req, res);
+});
+app.post("/mcp", async (req,res)=>{ ensureAcceptHeader(req); await handleMcpRequest(req,res,req.body); });
 app.post("/", async (req, res) => {
-  const t = new StreamableHTTPServerTransport({ enableJsonResponse: true });
-  res.on("close", () => t.close());
-  await server.connect(t);
-  await t.handleRequest(req, res, req.body);
+  ensureAcceptHeader(req);
+  await handleMcpRequest(req, res, req.body);
 });
 app.post("/tool/:name", async (req,res)=>{ try{ const h=handlers.get(req.params.name); if(!h) return res.status(404).json({error:"tool not found"}); res.json(await h(req.body||{})); }catch(e:any){ res.status(500).json({error:e.message}); }});
 app.listen(3002, ()=>console.log("test-mcp http://localhost:3002/{mcp|tool/*}"));


### PR DESCRIPTION
## Summary
- add GET handlers for `/` and `/mcp` in every MCP service so the Streamable HTTP transport can establish SSE sessions before tool discovery
- refactor the Accept header helper and shared MCP request handler to reuse logic across the REST endpoints while preserving JSON fallbacks

## Testing
- `pnpm -C mcp/pkg-mcp exec tsc --noEmit` *(fails: project is missing type declarations for express, zx, and the MCP SDK)*

------
https://chatgpt.com/codex/tasks/task_b_68e1c144ff9c8332a4f87059b0756239