### PR TITLE
Secure MCP configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,19 @@
 OPENAI_API_KEY=sk-...
 MODEL=gpt-5-codex
+
+# Optional: override MCP endpoints
+# MCP_BASE_URL=https://mcp.internal.example.com
+# REPO_MCP_URL=https://repo-mcp.internal.example.com
+# BUILD_MCP_URL=https://build-mcp.internal.example.com
+# TEST_MCP_URL=https://test-mcp.internal.example.com
+# LINT_MCP_URL=https://lint-mcp.internal.example.com
+# PKG_MCP_URL=https://pkg-mcp.internal.example.com
+# DESIGN_MCP_URL=https://design-mcp.internal.example.com
+
+# Approval policy defaults for MCP tools (always|never|auto)
+# MCP_REQUIRE_APPROVAL_DEFAULT=always
+# REPO_MCP_REQUIRE_APPROVAL=always
+
+# Shared API keys for /tool/* endpoints
+# MCP_TOOL_API_KEYS=local-dev-key
+# MCP_TOOL_API_KEY_HEADER=x-api-key

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Requisitos: Node 20+, pnpm, Python 3.11+, n8n, gh CLI. Para stacks específicos instala toolchains locales (Go/Java/Python/Flutter/etc.).
 
 1) MCP servers:
+   export MCP_TOOL_API_KEYS="local-dev-key"
+   # opcional: reemplaza REPO_MCP_TOOL_API_KEYS para claves por servicio
    pnpm -C mcp/repo-mcp i && pnpm -C mcp/repo-mcp start
    pnpm -C mcp/build-mcp i && pnpm -C mcp/build-mcp start
    pnpm -C mcp/test-mcp  i && pnpm -C mcp/test-mcp start
@@ -12,10 +14,13 @@ Requisitos: Node 20+, pnpm, Python 3.11+, n8n, gh CLI. Para stacks específicos 
 
 2) LangGraph:
    cp .env.example .env && export $(cat .env | xargs)
+   # Opcional: ajusta MCP_BASE_URL o REPO_MCP_URL para apuntar al dominio interno seguro
    pip install -r agents/langgraph/requirements.txt
    python agents/langgraph/main.py
 
 3) n8n: importa los JSON y configura endpoints.
+   - Define variables de entorno seguras (por ejemplo `REPO_MCP_URL=https://mcp-internal.local/repo-mcp`).
+   - Añade la cabecera `x-api-key` (o la definida en `MCP_TOOL_API_KEY_HEADER`) con el mismo secreto usado en los MCP.
 
 4) Define el stack de forma implícita o explícita:
    - Implícito: añade manifests (package.json, go.mod, pyproject.toml, etc.) y deja Discovery inferir.

--- a/mcp/test-mcp/src/index.ts
+++ b/mcp/test-mcp/src/index.ts
@@ -8,6 +8,24 @@ const HOST = '0.0.0.0';
 
 const server = new McpServer({ name: "test-mcp", version: "0.1.0" });
 const handlers = new Map<string, (a:any)=>Promise<any>>();
+
+const env = ((globalThis as unknown as { process?: { env?: Record<string, string | undefined> } }).process?.env) ?? {};
+const HEADER_NAME = env.MCP_TOOL_API_KEY_HEADER || "x-api-key";
+const rawKeyList = env.TEST_MCP_TOOL_API_KEYS || env.TEST_MCP_TOOL_API_KEY || env.MCP_TOOL_API_KEYS || env.MCP_TOOL_API_KEY || "";
+const ALLOWED_TOOL_KEYS = rawKeyList.split(",").map((value: string) => value.trim()).filter(Boolean);
+
+const requireApiKey = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (ALLOWED_TOOL_KEYS.length === 0) {
+    res.status(503).json({ error: "tool api key not configured" });
+    return;
+  }
+  const provided = req.get(HEADER_NAME) ?? (req.query[HEADER_NAME] as string | undefined);
+  if (!provided || !ALLOWED_TOOL_KEYS.includes(provided)) {
+    res.status(401).json({ error: "invalid api key" });
+    return;
+  }
+  next();
+};
 const FRONT = { react: 'pnpm -C frontend test -- --watch=false', vue: 'pnpm -C frontend test', flutter: 'flutter test' } as const;
 const BACK = { go: 'go test -race -short ./...', node: 'pnpm -C backend test', python: 'pytest -q' } as const;
 
@@ -58,7 +76,7 @@ app.post("/", async (req, res) => {
   ensureAcceptHeader(req);
   await handleMcpRequest(req, res, req.body);
 });
-app.post("/tool/:name", async (req,res)=>{ try{ const h=handlers.get(req.params.name); if(!h) return res.status(404).json({error:"tool not found"}); res.json(await h(req.body||{})); }catch(e:any){ res.status(500).json({error:e.message}); }});
+app.post("/tool/:name", requireApiKey, async (req,res)=>{ try{ const h=handlers.get(req.params.name); if(!h) return res.status(404).json({error:"tool not found"}); res.json(await h(req.body||{})); }catch(e:any){ res.status(500).json({error:e.message}); }});
 app.listen(PORT, () => {
   console.log(`repo-mcp http://${HOST}:${PORT}/{mcp|tool/*}`);
 });

--- a/n8n/feature-gate.workflow.json
+++ b/n8n/feature-gate.workflow.json
@@ -27,7 +27,7 @@
     {
       "parameters": {
         "requestMethod": "POST",
-        "url": "http://190.160.117.23:50000/tool/ci.run",
+        "url": "={{ ($env.REPO_MCP_URL || '').replace(/\\/$/, '') + '/tool/ci.run' }}",
         "jsonParameters": true,
         "options": {},
         "bodyParametersJson": "{ \"ref\": \"HEAD\" }"

--- a/n8n/nightly-refactor.workflow.json
+++ b/n8n/nightly-refactor.workflow.json
@@ -18,7 +18,7 @@
     {
       "parameters": {
         "requestMethod": "POST",
-        "url": "http://190.160.117.23:50002/tool/test.back",
+        "url": "={{ ($env.TEST_MCP_URL || '').replace(/\\/$/, '') + '/tool/test.back' }}",
         "jsonParameters": true,
         "options": {},
         "bodyParametersJson": "{ \"lang\": \"go\" }"
@@ -32,7 +32,7 @@
     {
       "parameters": {
         "requestMethod": "POST",
-        "url": "http://190.160.117.23:50000/tool/repo.pr",
+        "url": "={{ ($env.REPO_MCP_URL || '').replace(/\\/$/, '') + '/tool/repo.pr' }}",
         "jsonParameters": true,
         "options": {},
         "bodyParametersJson": "{ \"title\": \"chore(refactor): nightly\", \"branch\": \"auto/refactor-nightly\" }"


### PR DESCRIPTION
## Summary
- parameterize MCP server URLs and approval policies via environment variables for the LangGraph agent
- protect MCP /tool endpoints with API-key validation and document the configuration flow for developers and n8n
- point n8n workflows to environment-driven, TLS-friendly MCP endpoints instead of hard-coded public IPs

## Testing
- pnpm -C mcp/repo-mcp exec tsc --noEmit *(fails: missing type declarations in the existing project setup)*

------
https://chatgpt.com/codex/tasks/task_b_68e2ccb9e37c8332ab02b9ffaad69fa0